### PR TITLE
Port SampleBuilder from Pion

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,6 +6,7 @@ pub mod ivf_reader;
 pub mod ivf_writer;
 pub mod ogg_reader;
 pub mod ogg_writer;
+pub mod sample_builder;
 
 pub type ResetFn<R> = Box<dyn FnMut(usize) -> R>;
 

--- a/src/io/sample_builder/mod.rs
+++ b/src/io/sample_builder/mod.rs
@@ -45,7 +45,7 @@ pub struct SampleBuilder<T: Depacketizer> {
 impl<T: Depacketizer> SampleBuilder<T> {
     /// Constructs a new SampleBuilder.
     /// `max_late` is how long to wait until we can construct a completed [`Sample`].
-    /// max_late is measured in RTP packet sequence numbers.
+    /// `max_late` is measured in RTP packet sequence numbers.
     /// A large max_late will result in less packet loss but higher latency.
     /// The depacketizer extracts media samples from RTP packets.
     /// Several depacketizers are available in package [github.com/pion/rtp/codecs](https://github.com/webrtc-rs/rtp/tree/main/src/codecs).

--- a/src/io/sample_builder/mod.rs
+++ b/src/io/sample_builder/mod.rs
@@ -44,11 +44,11 @@ pub struct SampleBuilder<T: Depacketizer> {
 
 impl<T: Depacketizer> SampleBuilder<T> {
     /// Constructs a new SampleBuilder.
-    /// max_late is how long to wait until we can construct a completed media.Sample.
+    /// `max_late` is how long to wait until we can construct a completed [`Sample`].
     /// max_late is measured in RTP packet sequence numbers.
     /// A large max_late will result in less packet loss but higher latency.
     /// The depacketizer extracts media samples from RTP packets.
-    /// Several depacketizers are available in package github.com/pion/rtp/codecs.
+    /// Several depacketizers are available in package [github.com/pion/rtp/codecs](https://github.com/webrtc-rs/rtp/tree/main/src/codecs).
     pub fn new(max_late: u16, depacketizer: T, sample_rate: u32) -> Self {
         Self {
             max_late,
@@ -330,7 +330,7 @@ impl<T: Depacketizer> SampleBuilder<T> {
     }
 
     /// Compiles pushed RTP packets into media samples and then
-    /// returns the next valid sample with its associated RTP timestamp (or None if
+    /// returns the next valid sample with its associated RTP timestamp (or `None` if
     /// no sample is compiled).
     pub fn pop_with_timestamp(&mut self) -> Option<(Sample, u32)> {
         if let Some(sample) = self.pop() {

--- a/src/io/sample_builder/mod.rs
+++ b/src/io/sample_builder/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(test)]
+mod sample_builder_test;
+#[cfg(test)]
+mod sample_sequence_location_test;
+
 pub mod sample_sequence_location;
 
 use std::time::{Duration, SystemTime};

--- a/src/io/sample_builder/mod.rs
+++ b/src/io/sample_builder/mod.rs
@@ -1,0 +1,353 @@
+pub mod sample_sequence_location;
+
+use std::time::{Duration, SystemTime};
+
+use bytes::Bytes;
+use rtp::{packet::Packet, packetizer::Depacketizer};
+
+use crate::Sample;
+
+use self::sample_sequence_location::{Comparison, SampleSequenceLocation};
+
+/// SampleBuilder buffers packets until media frames are complete.
+pub struct SampleBuilder<T: Depacketizer> {
+    /// how many packets to wait until we get a valid Sample
+    max_late: u16,
+    /// max timestamp between old and new timestamps before dropping packets
+    max_late_timestamp: u32,
+    buffer: Vec<Option<Packet>>,
+    prepared_samples: Vec<Option<Sample>>,
+
+    /// Interface that allows us to take RTP packets to samples
+    depacketizer: T,
+
+    /// sample_rate allows us to compute duration of media.SamplecA
+    sample_rate: u32,
+
+    /// filled contains the head/tail of the packets inserted into the buffer
+    filled: SampleSequenceLocation,
+
+    /// active contains the active head/tail of the timestamp being actively processed
+    active: SampleSequenceLocation,
+
+    /// prepared contains the samples that have been processed to date
+    prepared: SampleSequenceLocation,
+
+    /// number of packets forced to be dropped
+    dropped_packets: u16,
+}
+
+impl<T: Depacketizer> SampleBuilder<T> {
+    /// Constructs a new SampleBuilder.
+    /// max_late is how long to wait until we can construct a completed media.Sample.
+    /// max_late is measured in RTP packet sequence numbers.
+    /// A large max_late will result in less packet loss but higher latency.
+    /// The depacketizer extracts media samples from RTP packets.
+    /// Several depacketizers are available in package github.com/pion/rtp/codecs.
+    pub fn new(max_late: u16, depacketizer: T, sample_rate: u32) -> Self {
+        Self {
+            max_late,
+            max_late_timestamp: 0,
+            buffer: vec![None; u16::MAX as usize + 1],
+            prepared_samples: (0..=u16::MAX as usize).map(|_| None).collect(),
+            depacketizer,
+            sample_rate,
+            filled: SampleSequenceLocation::new(),
+            active: SampleSequenceLocation::new(),
+            prepared: SampleSequenceLocation::new(),
+            dropped_packets: 0,
+        }
+    }
+
+    fn too_old(&self, location: &SampleSequenceLocation) -> bool {
+        if self.max_late_timestamp == 0 {
+            return false;
+        }
+
+        let mut found_head: Option<u32> = None;
+        let mut found_tail: Option<u32> = None;
+
+        let mut i = location.head;
+        while i != location.tail {
+            if let Some(ref packet) = self.buffer[i as usize] {
+                found_head = Some(packet.header.timestamp);
+                break;
+            }
+            i = i.wrapping_add(1);
+        }
+
+        if found_head == None {
+            return false;
+        }
+
+        let mut i = location.tail - 1;
+        while i != location.head {
+            if let Some(ref packet) = self.buffer[i as usize] {
+                found_tail = Some(packet.header.timestamp);
+                break;
+            }
+            i = i.wrapping_sub(1);
+        }
+
+        if found_tail == None {
+            return false;
+        }
+
+        return timestamp_distance(found_head.unwrap(), found_tail.unwrap())
+            > self.max_late_timestamp;
+    }
+
+    /// Returns the timestamp associated with a given sample location
+    fn fetch_timestamp(&self, location: &SampleSequenceLocation) -> Option<u32> {
+        if location.empty() {
+            None
+        } else {
+            Some(
+                (self.buffer[location.head as usize])
+                    .as_ref()?
+                    .header
+                    .timestamp,
+            )
+        }
+    }
+
+    fn release_packet(&mut self, i: u16) {
+        self.buffer[i as usize] = None;
+    }
+
+    /// Clears all buffers that have already been consumed by
+    /// popping.
+    fn purge_consumed_buffers(&mut self) {
+        let active = self.active;
+        self.purge_consumed_location(&active, false);
+    }
+
+    /// Clears all buffers that have already been consumed
+    /// during a sample building method.
+    fn purge_consumed_location(&mut self, consume: &SampleSequenceLocation, force_consume: bool) {
+        if !self.filled.has_data() {
+            return;
+        }
+        match consume.compare(self.filled.head) {
+            Comparison::Inside if force_consume => {
+                self.release_packet(self.filled.head);
+                self.filled.head += 1;
+            }
+            Comparison::Before => {
+                self.release_packet(self.filled.head);
+                self.filled.head += 1;
+            }
+            _ => {}
+        }
+    }
+
+    /// Flushes all buffers that are already consumed or those buffers
+    /// that are too late to consume.
+    fn purge_buffers(&mut self) {
+        self.purge_consumed_buffers();
+
+        while (self.too_old(&self.filled) || (self.filled.count() > self.max_late))
+            && self.filled.has_data()
+        {
+            if self.active.empty() {
+                // refill the active based on the filled packets
+                self.active = self.filled;
+            }
+
+            if self.active.has_data() && (self.active.head == self.filled.head) {
+                // attempt to force the active packet to be consumed even though
+                // outstanding data may be pending arrival
+                if self.build_sample(true).is_some() {
+                    continue;
+                }
+
+                // could not build the sample so drop it
+                self.active.head = self.active.head.wrapping_add(1);
+                self.dropped_packets += 1;
+            }
+
+            self.release_packet(self.filled.head);
+            self.filled.head = self.filled.head.wrapping_add(1);
+        }
+    }
+
+    /// Adds an RTP Packet to self's buffer.
+    ///
+    /// Push does not copy the input. If you wish to reuse
+    /// this memory make sure to copy before calling push
+    pub fn push(&mut self, p: Packet) {
+        let sequence_number = p.header.sequence_number;
+        self.buffer[sequence_number as usize] = Some(p);
+        match self.filled.compare(sequence_number) {
+            Comparison::Void => {
+                self.filled.head = sequence_number;
+                self.filled.tail = sequence_number.wrapping_add(1);
+            }
+            Comparison::Before => {
+                self.filled.head = sequence_number;
+            }
+            Comparison::After => {
+                self.filled.tail = sequence_number.wrapping_add(1);
+            }
+            _ => {}
+        }
+        self.purge_buffers();
+    }
+
+    /// Creates a sample from a valid collection of RTP Packets by
+    /// walking forwards building a sample if everything looks good clear and
+    /// update buffer+values
+    fn build_sample(&mut self, purging_buffers: bool) -> Option<()> {
+        if self.active.empty() {
+            self.active = self.filled;
+        }
+
+        if self.active.empty() {
+            return None;
+        }
+
+        if self.filled.compare(self.active.tail) == Comparison::Inside {
+            self.active.tail = self.filled.tail;
+        }
+
+        let mut consume = SampleSequenceLocation::new();
+
+        let mut i = self.active.head;
+        while let Some(ref packet) = self.buffer[i as usize] {
+            if self.active.compare(i) == Comparison::After {
+                break;
+            }
+            if self
+                .depacketizer
+                .is_partition_tail(packet.header.marker, &packet.payload)
+            {
+                consume.head = self.active.head;
+                consume.tail = i.wrapping_add(1);
+                break;
+            }
+            if let Some(head_timestamp) = self.fetch_timestamp(&self.active) {
+                if packet.header.timestamp != head_timestamp {
+                    consume.head = self.active.head;
+                    consume.tail = i;
+                    break;
+                }
+            }
+            i = i.wrapping_add(1);
+        }
+
+        if consume.empty() {
+            return None;
+        }
+
+        if !purging_buffers && self.buffer[consume.tail as usize].is_none() {
+            // wait for the next packet after this set of packets to arrive
+            // to ensure at least one post sample timestamp is known
+            // (unless we have to release right now)
+            return None;
+        }
+
+        let sample_timestamp = self.fetch_timestamp(&self.active).unwrap_or(0);
+        let mut after_timestamp = sample_timestamp;
+
+        // scan for any packet after the current and use that time stamp as the diff point
+        for i in consume.tail..self.active.tail {
+            if let Some(ref packet) = self.buffer[i as usize] {
+                after_timestamp = packet.header.timestamp;
+                break;
+            }
+        }
+
+        // the head set of packets is now fully consumed
+        self.active.head = consume.tail;
+
+        // prior to decoding all the packets, check if this packet
+        // would end being disposed anyway
+        if !self
+            .depacketizer
+            .is_partition_head(&self.buffer[consume.head as usize].as_ref()?.payload)
+        {
+            self.dropped_packets += consume.count();
+            self.purge_consumed_location(&consume, true);
+            self.purge_consumed_buffers();
+            return None;
+        }
+
+        // merge all the buffers into a sample
+        let mut data: Vec<u8> = Vec::new();
+        let mut i = consume.head;
+        while i != consume.tail {
+            let p = self
+                .depacketizer
+                .depacketize(&self.buffer[i as usize].as_ref()?.payload)
+                .ok()?;
+            data.extend_from_slice(&p);
+            i = i.wrapping_add(1);
+        }
+        let samples = after_timestamp - sample_timestamp;
+
+        let sample = Sample {
+            data: Bytes::copy_from_slice(&data),
+            timestamp: SystemTime::now(),
+            duration: Duration::from_secs_f64((samples as f64) / (self.sample_rate as f64)),
+            packet_timestamp: sample_timestamp,
+            prev_dropped_packets: self.dropped_packets,
+        };
+
+        self.dropped_packets = 0;
+
+        self.prepared_samples[self.prepared.tail as usize] = Some(sample);
+        self.prepared.tail = self.prepared.tail.wrapping_add(1);
+
+        self.purge_consumed_location(&consume, true);
+        self.purge_consumed_buffers();
+
+        Some(())
+    }
+
+    /// Compiles pushed RTP packets into media samples and then
+    /// returns the next valid sample (or None if no sample is compiled).
+    pub fn pop(&mut self) -> Option<Sample> {
+        self.build_sample(false);
+        if self.prepared.empty() {
+            return None;
+        }
+        let result = std::mem::replace(
+            &mut self.prepared_samples[self.prepared.head as usize],
+            None,
+        );
+        self.prepared.head = self.prepared.head.wrapping_add(1);
+        return result;
+    }
+
+    /// Compiles pushed RTP packets into media samples and then
+    /// returns the next valid sample with its associated RTP timestamp (or None if
+    /// no sample is compiled).
+    pub fn pop_with_timestamp(&mut self) -> Option<(Sample, u32)> {
+        if let Some(sample) = self.pop() {
+            let timestamp = sample.packet_timestamp;
+            Some((sample, timestamp))
+        } else {
+            None
+        }
+    }
+}
+
+/// Computes the distance between two sequence numbers
+pub(crate) fn seqnum_distance(x: u16, y: u16) -> u16 {
+    let diff = x as i32 - y as i32;
+    if diff < 0 {
+        (-diff) as u16
+    } else {
+        diff as u16
+    }
+}
+
+/// Computes the distance between two timestamps
+pub(crate) fn timestamp_distance(x: u32, y: u32) -> u32 {
+    let diff = x as i64 - y as i64;
+    if diff < 0 {
+        (-diff) as u32
+    } else {
+        diff as u32
+    }
+}

--- a/src/io/sample_builder/mod.rs
+++ b/src/io/sample_builder/mod.rs
@@ -64,6 +64,12 @@ impl<T: Depacketizer> SampleBuilder<T> {
         }
     }
 
+    pub fn with_max_time_delay(mut self, max_late_duration: Duration) -> Self {
+        self.max_late_timestamp =
+            (self.sample_rate as u128 * max_late_duration.as_millis() / 1000) as u32;
+        self
+    }
+
     fn too_old(&self, location: &SampleSequenceLocation) -> bool {
         if self.max_late_timestamp == 0 {
             return false;

--- a/src/io/sample_builder/sample_builder_test.rs
+++ b/src/io/sample_builder/sample_builder_test.rs
@@ -25,6 +25,15 @@ pub struct FakeDepacketizer {
     head_bytes: Vec<bytes::Bytes>,
 }
 
+impl FakeDepacketizer {
+    fn new() -> Self {
+        Self {
+            head_checker: false,
+            head_bytes: vec![],
+        }
+    }
+}
+
 impl Depacketizer for FakeDepacketizer {
     fn depacketize(&mut self, b: &Bytes) -> std::result::Result<bytes::Bytes, rtp::Error> {
         Ok(b.clone())
@@ -54,7 +63,6 @@ impl Depacketizer for FakeDepacketizer {
     }
 }
 
-// .go uses testing.T as parameter, have to look into that
 #[test]
 pub fn test_sample_builder() {
     let test_data: Vec<SampleBuilderTest> = vec![
@@ -67,7 +75,7 @@ pub fn test_sample_builder() {
                     timestamp: 5,
                     ..Default::default()
                 },
-                payload: bytes!(1u8),
+                payload: bytes!(1),
                 ..Default::default()
             }],
             samples: vec![],
@@ -85,7 +93,7 @@ pub fn test_sample_builder() {
                     marker: true,
                     ..Default::default()
                 },
-                payload: bytes!(1u8),
+                payload: bytes!(1),
                 ..Default::default()
             }],
             samples: vec![],
@@ -104,7 +112,7 @@ pub fn test_sample_builder() {
                         timestamp: 5,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -114,7 +122,7 @@ pub fn test_sample_builder() {
                         timestamp: 6,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -124,21 +132,21 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
             ],
             samples: vec![
                 Sample {
                     // First sample
-                    data: bytes!(1u8),
+                    data: bytes!(1),
                     duration: Duration::from_secs(1), // technically this is the default value, but since it was in .go source....
                     packet_timestamp: 5,
                     ..Default::default()
                 },
                 Sample {
                     // Second sample
-                    data: bytes!(2u8),
+                    data: bytes!(2),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 6,
                     ..Default::default()
@@ -160,7 +168,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -170,7 +178,7 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -180,7 +188,7 @@ pub fn test_sample_builder() {
                         timestamp: 9,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
                 Packet {
@@ -190,7 +198,7 @@ pub fn test_sample_builder() {
                         timestamp: 11,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
                 Packet {
@@ -200,7 +208,7 @@ pub fn test_sample_builder() {
                         timestamp: 13,
                         ..Default::default()
                     },
-                    payload: bytes!(5u8),
+                    payload: bytes!(5),
                     ..Default::default()
                 },
                 Packet {
@@ -210,7 +218,7 @@ pub fn test_sample_builder() {
                         timestamp: 15,
                         ..Default::default()
                     },
-                    payload: bytes!(6u8),
+                    payload: bytes!(6),
                     ..Default::default()
                 },
                 Packet {
@@ -220,13 +228,13 @@ pub fn test_sample_builder() {
                         timestamp: 17,
                         ..Default::default()
                     },
-                    payload: bytes!(7u8),
+                    payload: bytes!(7),
                     ..Default::default()
                 },
             ],
             samples: vec![Sample {
                 // First sample
-                data: bytes!(1u8),
+                data: bytes!(1),
                 duration: Duration::from_secs(2),
                 packet_timestamp: 5,
                 ..Default::default()
@@ -246,7 +254,7 @@ pub fn test_sample_builder() {
                         timestamp: 5,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -256,7 +264,7 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -266,7 +274,7 @@ pub fn test_sample_builder() {
                         timestamp: 9,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
                 Packet {
@@ -276,7 +284,7 @@ pub fn test_sample_builder() {
                         timestamp: 11,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
                 Packet {
@@ -286,7 +294,7 @@ pub fn test_sample_builder() {
                         timestamp: 13,
                         ..Default::default()
                     },
-                    payload: bytes!(5u8),
+                    payload: bytes!(5),
                     ..Default::default()
                 },
                 Packet {
@@ -296,7 +304,7 @@ pub fn test_sample_builder() {
                         timestamp: 15,
                         ..Default::default()
                     },
-                    payload: bytes!(6u8),
+                    payload: bytes!(6),
                     ..Default::default()
                 },
                 Packet {
@@ -306,7 +314,7 @@ pub fn test_sample_builder() {
                         timestamp: 17,
                         ..Default::default()
                     },
-                    payload: bytes!(7u8),
+                    payload: bytes!(7),
                     ..Default::default()
                 },
             ],
@@ -327,7 +335,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -338,7 +346,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -348,7 +356,7 @@ pub fn test_sample_builder() {
                         timestamp: 9,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
                 Packet {
@@ -358,7 +366,7 @@ pub fn test_sample_builder() {
                         timestamp: 11,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
                 Packet {
@@ -368,7 +376,7 @@ pub fn test_sample_builder() {
                         timestamp: 13,
                         ..Default::default()
                     },
-                    payload: bytes!(5u8),
+                    payload: bytes!(5),
                     ..Default::default()
                 },
                 Packet {
@@ -378,7 +386,7 @@ pub fn test_sample_builder() {
                         timestamp: 15,
                         ..Default::default()
                     },
-                    payload: bytes!(6u8),
+                    payload: bytes!(6),
                     ..Default::default()
                 },
                 Packet {
@@ -388,21 +396,21 @@ pub fn test_sample_builder() {
                         timestamp: 17,
                         ..Default::default()
                     },
-                    payload: bytes!(7u8),
+                    payload: bytes!(7),
                     ..Default::default()
                 },
             ],
             samples: vec![
                 Sample {
                     // First (dropped) sample
-                    data: bytes!(1u8),
+                    data: bytes!(1),
                     duration: Duration::from_secs(2),
                     packet_timestamp: 5,
                     ..Default::default()
                 },
                 Sample {
                     // First correct sample
-                    data: bytes!(2u8),
+                    data: bytes!(2),
                     duration: Duration::from_secs(2),
                     packet_timestamp: 7,
                     prev_dropped_packets: 1,
@@ -422,10 +430,9 @@ pub fn test_sample_builder() {
                     header: Header {
                         sequence_number: 5000,
                         timestamp: 5,
-                        marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -433,10 +440,9 @@ pub fn test_sample_builder() {
                     header: Header {
                         sequence_number: 5001,
                         timestamp: 6,
-                        marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -446,7 +452,7 @@ pub fn test_sample_builder() {
                         timestamp: 6,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
                 Packet {
@@ -456,21 +462,21 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
             ],
             samples: vec![
                 Sample {
                     // First sample
-                    data: bytes!(1u8),
+                    data: bytes!(1),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 5,
                     ..Default::default()
                 },
                 Sample {
                     // Second (duplicate) correct sample
-                    data: bytes!(2u8, 2u8),
+                    data: bytes!(2, 3),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 6,
                     ..Default::default()
@@ -492,7 +498,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -503,7 +509,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -513,7 +519,7 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
             ],
@@ -534,7 +540,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -545,7 +551,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -555,12 +561,12 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
             ],
             with_head_checker: true,
-            head_bytes: vec![bytes!(2u8)],
+            head_bytes: vec![bytes!(2)],
             samples: vec![],
             max_late: 50,
             max_late_timestamp: Duration::from_secs(0),
@@ -578,7 +584,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -589,7 +595,7 @@ pub fn test_sample_builder() {
                         marker: true,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -599,7 +605,7 @@ pub fn test_sample_builder() {
                         timestamp: 7,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
             ],
@@ -621,7 +627,7 @@ pub fn test_sample_builder() {
                         timestamp: 1,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -631,7 +637,7 @@ pub fn test_sample_builder() {
                         timestamp: 2,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -641,7 +647,7 @@ pub fn test_sample_builder() {
                         timestamp: 3,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
                 Packet {
@@ -651,7 +657,7 @@ pub fn test_sample_builder() {
                         timestamp: 4,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
                 Packet {
@@ -661,7 +667,7 @@ pub fn test_sample_builder() {
                         timestamp: 5,
                         ..Default::default()
                     },
-                    payload: bytes!(5u8),
+                    payload: bytes!(5),
                     ..Default::default()
                 },
                 Packet {
@@ -671,42 +677,42 @@ pub fn test_sample_builder() {
                         timestamp: 6,
                         ..Default::default()
                     },
-                    payload: bytes!(6u8),
+                    payload: bytes!(6),
                     ..Default::default()
                 },
             ],
             samples: vec![
                 Sample {
                     // First sample
-                    data: bytes!(1u8),
+                    data: bytes!(1),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 1,
                     ..Default::default()
                 },
                 Sample {
                     // Second sample
-                    data: bytes!(2u8),
+                    data: bytes!(2),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 2,
                     ..Default::default()
                 },
                 Sample {
                     // Third sample
-                    data: bytes!(3u8),
+                    data: bytes!(3),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 3,
                     ..Default::default()
                 },
                 Sample {
                     // Fourth sample
-                    data: bytes!(4u8),
+                    data: bytes!(4),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 4,
                     ..Default::default()
                 },
                 Sample {
                     // Fifth sample
-                    data: bytes!(5u8),
+                    data: bytes!(5),
                     duration: Duration::from_secs(1),
                     packet_timestamp: 5,
                     ..Default::default()
@@ -727,7 +733,7 @@ pub fn test_sample_builder() {
                         timestamp: 1,
                         ..Default::default()
                     },
-                    payload: bytes!(1u8),
+                    payload: bytes!(1),
                     ..Default::default()
                 },
                 Packet {
@@ -737,7 +743,7 @@ pub fn test_sample_builder() {
                         timestamp: 2,
                         ..Default::default()
                     },
-                    payload: bytes!(2u8),
+                    payload: bytes!(2),
                     ..Default::default()
                 },
                 Packet {
@@ -747,7 +753,7 @@ pub fn test_sample_builder() {
                         timestamp: 3,
                         ..Default::default()
                     },
-                    payload: bytes!(3u8),
+                    payload: bytes!(3),
                     ..Default::default()
                 },
                 Packet {
@@ -757,7 +763,7 @@ pub fn test_sample_builder() {
                         timestamp: 4000,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
                 Packet {
@@ -767,7 +773,7 @@ pub fn test_sample_builder() {
                         timestamp: 4000,
                         ..Default::default()
                     },
-                    payload: bytes!(5u8),
+                    payload: bytes!(5),
                     ..Default::default()
                 },
                 Packet {
@@ -777,7 +783,7 @@ pub fn test_sample_builder() {
                         timestamp: 4002,
                         ..Default::default()
                     },
-                    payload: bytes!(6u8),
+                    payload: bytes!(6),
                     ..Default::default()
                 },
                 Packet {
@@ -787,7 +793,7 @@ pub fn test_sample_builder() {
                         timestamp: 7000,
                         ..Default::default()
                     },
-                    payload: bytes!(4u8),
+                    payload: bytes!(4),
                     ..Default::default()
                 },
                 Packet {
@@ -797,20 +803,20 @@ pub fn test_sample_builder() {
                         timestamp: 7001,
                         ..Default::default()
                     },
-                    payload: bytes!(5u8),
+                    payload: bytes!(5),
                     ..Default::default()
                 },
             ],
             samples: vec![Sample {
                 // First sample
-                data: bytes!(4u8, 5u8),
+                data: bytes!(4, 5),
                 duration: Duration::from_secs(2),
                 packet_timestamp: 4000,
                 prev_dropped_packets: 13,
                 ..Default::default()
             }],
             with_head_checker: true,
-            head_bytes: vec![bytes!(4u8)],
+            head_bytes: vec![bytes!(4)],
             max_late: 50,
             max_late_timestamp: Duration::from_secs(2000),
             ..Default::default()
@@ -851,14 +857,7 @@ pub fn test_sample_builder() {
 // SampleBuilder should respect maxLate if we popped successfully but then have a gap larger then maxLate
 #[test]
 fn test_sample_builder_max_late() {
-    let mut s = SampleBuilder::new(
-        50,
-        FakeDepacketizer {
-            head_bytes: vec![],
-            head_checker: false,
-        },
-        1,
-    );
+    let mut s = SampleBuilder::new(50, FakeDepacketizer::new(), 1);
 
     s.push(Packet {
         header: Header {
@@ -961,4 +960,169 @@ fn test_sample_builder_max_late() {
         s.pop(),
         "Failed to build samples after large gap"
     );
+}
+
+#[test]
+fn test_seqnum_distance() {
+    struct TestData {
+        x: u16,
+        y: u16,
+        d: u16,
+    }
+    let test_data = vec![
+        TestData {
+            x: 0x0001,
+            y: 0x0003,
+            d: 0x0002,
+        },
+        TestData {
+            x: 0x0003,
+            y: 0x0001,
+            d: 0x0002,
+        },
+        TestData {
+            x: 0xFFF3,
+            y: 0xFFF1,
+            d: 0x0002,
+        },
+        TestData {
+            x: 0xFFF1,
+            y: 0xFFF3,
+            d: 0x0002,
+        },
+        TestData {
+            x: 0xFFFF,
+            y: 0x0001,
+            d: 0x0002,
+        },
+        TestData {
+            x: 0x0001,
+            y: 0xFFFF,
+            d: 0x0002,
+        },
+    ];
+
+    for data in test_data {
+        assert_eq!(
+            seqnum_distance(data.x, data.y),
+            data.d,
+            "seqnum_distance({}, {}) returned {} which must be {}",
+            data.x,
+            data.y,
+            seqnum_distance(data.x, data.y),
+            data.d
+        );
+    }
+}
+
+#[test]
+fn test_sample_builder_clean_reference() {
+    for seq_start in [0 as u16, 0xfff8, 0xfffe] {
+        let mut s = SampleBuilder::new(10, FakeDepacketizer::new(), 1);
+        s.push(Packet {
+            header: Header {
+                sequence_number: seq_start,
+                timestamp: 0,
+                ..Default::default()
+            },
+            payload: bytes!(0x01),
+        });
+        s.push(Packet {
+            header: Header {
+                sequence_number: seq_start.wrapping_add(1),
+                timestamp: 0,
+                ..Default::default()
+            },
+            payload: bytes!(0x02),
+        });
+        s.push(Packet {
+            header: Header {
+                sequence_number: seq_start.wrapping_add(2),
+                timestamp: 0,
+                ..Default::default()
+            },
+            payload: bytes!(0x03),
+        });
+        let pkt4 = Packet {
+            header: Header {
+                sequence_number: seq_start.wrapping_add(14),
+                timestamp: 120,
+                ..Default::default()
+            },
+            payload: bytes!(0x04),
+        };
+        s.push(pkt4.clone());
+        let pkt5 = Packet {
+            header: Header {
+                sequence_number: seq_start.wrapping_add(12),
+                timestamp: 120,
+                ..Default::default()
+            },
+            payload: bytes!(0x05),
+        };
+        s.push(pkt5.clone());
+
+        for i in 0..3 {
+            assert_eq!(
+                None,
+                s.buffer[seq_start.wrapping_add(i) as usize],
+                "Old packet ({}) is not unreferenced (seq_start: {}, max_late: 10, pushed: 12)",
+                i,
+                seq_start
+            );
+        }
+        assert_eq!(Some(pkt4), s.buffer[seq_start.wrapping_add(14) as usize]);
+        assert_eq!(Some(pkt5), s.buffer[seq_start.wrapping_add(12) as usize]);
+    }
+}
+
+#[test]
+fn test_sample_builder_push_max_zero() {
+    let pkts = vec![Packet {
+        header: Header {
+            sequence_number: 0,
+            timestamp: 0,
+            marker: true,
+            ..Default::default()
+        },
+        payload: bytes!(0x01),
+    }];
+    let d = FakeDepacketizer {
+        head_checker: true,
+        head_bytes: vec![bytes!(0x01)],
+    };
+    let mut s = SampleBuilder::new(0, d, 1);
+    s.push(pkts[0].clone());
+    assert_eq!(s.pop().is_some(), true, "Should expect a popped sample.")
+}
+
+#[test]
+fn test_pop_with_timestamp() {
+    let mut s = SampleBuilder::new(0, FakeDepacketizer::new(), 1);
+    assert_eq!(None, s.pop_with_timestamp());
+}
+
+#[test]
+fn test_sample_builder_data() {
+    let mut s = SampleBuilder::new(10, FakeDepacketizer::new(), 1);
+    let mut j: usize = 0;
+    for i in 0..0x20000 as usize {
+        let p = Packet {
+            header: Header {
+                sequence_number: i as u16,
+                timestamp: (i + 42) as u32,
+                ..Default::default()
+            },
+            payload: Bytes::copy_from_slice(&[i as u8]),
+        };
+        s.push(p);
+        while let Some((sample, ts)) = s.pop_with_timestamp() {
+            assert_eq!(ts, (j + 42) as u32, "timestamp");
+            assert_eq!(sample.data.len(), 1, "data length");
+            assert_eq!(j as u8, sample.data[0], "timestamp");
+            j += 1;
+        }
+    }
+    // only the last packet should be dropped
+    assert_eq!(j, 0x1FFFF);
 }

--- a/src/io/sample_builder/sample_builder_test.rs
+++ b/src/io/sample_builder/sample_builder_test.rs
@@ -1,0 +1,771 @@
+
+use rtp::packetizer::Depacketizer;
+
+use super::*;
+
+// Turns u8 integers into Bytes Array
+macro_rules! bytes {
+    ($($item:expr),*) => ({
+        static STATIC_SLICE: &'static [u8] = &[$($item), *];
+        Bytes::from_static(STATIC_SLICE)
+    });
+}
+#[derive(Default)]
+pub struct SampleBuilderTest {
+    message: String,
+    packets: Vec<rtp::packet::Packet>,
+    with_head_checker: bool,
+    head_bytes: Vec<bytes::Bytes>,
+    samples: Vec<Sample>,
+    max_late: u16,
+    max_late_timestamp: Duration,
+}
+
+pub struct FakeDepacketizer {
+    head_checker: bool,
+    head_bytes: Vec<bytes::Bytes>,
+}
+
+impl Depacketizer for FakeDepacketizer {
+    fn depacketize(&mut self, b: &Bytes) -> std::result::Result<bytes::Bytes, rtp::Error> {
+        Ok(b.clone())
+    }
+
+    /// Checks if the packet is at the beginning of a partition.  This
+    /// should return false if the result could not be determined, in
+    /// which case the caller will detect timestamp discontinuities.
+    fn is_partition_head(&self, payload: &Bytes) -> bool {
+        if self.head_checker == false {
+            // from .go: simulates a bug in 3.0 version, the tests should not assume the bug
+            return true;
+        }
+
+        for b in self.head_bytes.clone() {
+            if *payload == b {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Checks if the packet is at the end of a partition.  This should
+    /// return false if the result could not be determined.
+    fn is_partition_tail(&self, marker: bool, payload: &Bytes) -> bool {
+        return marker;
+    }
+}
+
+// .go uses testing.T as parameter, have to look into that
+#[test]
+pub fn test_sample_builder() {
+    let test_data: Vec<SampleBuilderTest> = Vec::from([
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder shouldn't emit anything if only one RTP packet has been pushed",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet {
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder shouldn't emit anything if only one RTP packet has been pushed even if the marker bit is set",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet {
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5,
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder should emit two packets, we had three packets with unique timestamps",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5001,
+                    timestamp: 6, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([Sample { // First sample
+                data: bytes!(1u8),
+                duration: Duration::from_secs(1), // technically this is the default value, but since it was in .go source....
+                packet_timestamp: 5,
+                ..Default::default()
+            },
+            Sample { // Second sample
+                data: bytes!(2u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 6,
+                ..Default::default()
+            }]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder should emit one packet, we had a packet end of sequence marker and run out of space",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5, 
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5004,
+                    timestamp: 9, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fourth packet
+                header: rtp::header::Header {
+                    sequence_number: 5006,
+                    timestamp: 11, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fifth packet
+                header: rtp::header::Header {
+                    sequence_number: 5008,
+                    timestamp: 13, 
+                    ..Default::default()
+                },
+                payload: bytes!(5u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Sixth packet
+                header: rtp::header::Header {
+                    sequence_number: 5010,
+                    timestamp: 15, 
+                    ..Default::default()
+                },
+                payload: bytes!(6u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Seventh packet
+                header: rtp::header::Header {
+                    sequence_number: 5012,
+                    timestamp: 17, 
+                    ..Default::default()
+                },
+                payload: bytes!(7u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([Sample { // First sample
+                data: bytes!(1u8),
+                duration: Duration::from_secs(2), 
+                packet_timestamp: 5,
+                ..Default::default()
+            }]),
+            max_late: 5,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder shouldn't emit any packet, we do not have a valid end of sequence and run out of space",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5004,
+                    timestamp: 9, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fourth packet
+                header: rtp::header::Header {
+                    sequence_number: 5006,
+                    timestamp: 11, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fifth packet
+                header: rtp::header::Header {
+                    sequence_number: 5008,
+                    timestamp: 13, 
+                    ..Default::default()
+                },
+                payload: bytes!(5u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Sixth packet
+                header: rtp::header::Header {
+                    sequence_number: 5010,
+                    timestamp: 15, 
+                    ..Default::default()
+                },
+                payload: bytes!(6u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Seventh packet
+                header: rtp::header::Header {
+                    sequence_number: 5012,
+                    timestamp: 17, 
+                    ..Default::default()
+                },
+                payload: bytes!(7u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([]),
+            max_late: 5,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder should emit one packet, we had a packet end of sequence marker and run out of space",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5, 
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 7,
+                    marker: true, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5004,
+                    timestamp: 9, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fourth packet
+                header: rtp::header::Header {
+                    sequence_number: 5006,
+                    timestamp: 11, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fifth packet
+                header: rtp::header::Header {
+                    sequence_number: 5008,
+                    timestamp: 13, 
+                    ..Default::default()
+                },
+                payload: bytes!(5u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Sixth packet
+                header: rtp::header::Header {
+                    sequence_number: 5010,
+                    timestamp: 15, 
+                    ..Default::default()
+                },
+                payload: bytes!(6u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Seventh packet
+                header: rtp::header::Header {
+                    sequence_number: 5012,
+                    timestamp: 17, 
+                    ..Default::default()
+                },
+                payload: bytes!(7u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([Sample { // First (dropped) sample
+                data: bytes!(1u8),
+                duration: Duration::from_secs(2), 
+                packet_timestamp: 5,
+                ..Default::default()
+            },
+            Sample { // First correct sample
+                data: bytes!(2u8),
+                duration: Duration::from_secs(2), 
+                packet_timestamp: 7,
+                prev_dropped_packets: 1,
+                ..Default::default()
+            }]),
+            max_late: 5,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder should emit one packet, we had two packets but with duplicate timestamps",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5, 
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5001,
+                    timestamp: 6,
+                    marker: true, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 6, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fourth packet
+                header: rtp::header::Header {
+                    sequence_number: 5003,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([Sample { // First sample
+                data: bytes!(1u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 5,
+                ..Default::default()
+            },
+            Sample { // Second (duplicate) correct sample
+                data: bytes!(2u8, 2u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 6,
+                ..Default::default()
+            }]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder shouldn't emit a packet because we have a gap before a valid one",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5, 
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5007,
+                    timestamp: 6,
+                    marker: true, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5008,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder shouldn't emit a packet after a gap as there are gaps and have not reached maxLate yet",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5, 
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5007,
+                    timestamp: 6,
+                    marker: true, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5008,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            }]),
+            with_head_checker: true,
+            head_bytes: Vec::from([bytes!(2u8)]),
+            samples: Vec::from([]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder shouldn't emit a packet after a gap if PartitionHeadChecker doesn't assume it head",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 5, 
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5007,
+                    timestamp: 6,
+                    marker: true, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5008,
+                    timestamp: 7, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            }]),
+            with_head_checker: true,
+            head_bytes: Vec::from([]),
+            samples: Vec::from([]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder should emit multiple valid packets",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 1, 
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5001,
+                    timestamp: 2, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 3, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fourth packet
+                header: rtp::header::Header {
+                    sequence_number: 5003,
+                    timestamp: 4, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fifth packet
+                header: rtp::header::Header {
+                    sequence_number: 5004,
+                    timestamp: 5, 
+                    ..Default::default()
+                },
+                payload: bytes!(5u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Sixth packet
+                header: rtp::header::Header {
+                    sequence_number: 5005,
+                    timestamp: 6, 
+                    ..Default::default()
+                },
+                payload: bytes!(6u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([Sample { // First sample
+                data: bytes!(1u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 1,
+                ..Default::default()
+            },
+            Sample { // Second sample
+                data: bytes!(2u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 2,
+                ..Default::default()
+            },
+            Sample { // Third sample
+                data: bytes!(3u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 3,
+                ..Default::default()
+            },
+            Sample { // Fourth sample
+                data: bytes!(4u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 4,
+                ..Default::default()
+            },
+            Sample { // Fifth sample
+                data: bytes!(5u8),
+                duration: Duration::from_secs(1), 
+                packet_timestamp: 5,
+                ..Default::default()
+            },]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(0),
+            ..Default::default()
+        },
+        SampleBuilderTest {
+            message: String::from(
+                "Sample builder should skipt time stamps too old",
+            ),
+            packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
+                header: rtp::header::Header {
+                    sequence_number: 5000,
+                    timestamp: 1, 
+                    ..Default::default()
+                },
+                payload: bytes!(1u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Second packet
+                header: rtp::header::Header {
+                    sequence_number: 5001,
+                    timestamp: 2, 
+                    ..Default::default()
+                },
+                payload: bytes!(2u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Third packet
+                header: rtp::header::Header {
+                    sequence_number: 5002,
+                    timestamp: 3, 
+                    ..Default::default()
+                },
+                payload: bytes!(3u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fourth packet
+                header: rtp::header::Header {
+                    sequence_number: 5013,
+                    timestamp: 4000, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Fifth packet
+                header: rtp::header::Header {
+                    sequence_number: 5014,
+                    timestamp: 4000, 
+                    ..Default::default()
+                },
+                payload: bytes!(5u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Sixth packet
+                header: rtp::header::Header {
+                    sequence_number: 5015,
+                    timestamp: 4002, 
+                    ..Default::default()
+                },
+                payload: bytes!(6u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Seventh packet
+                header: rtp::header::Header {
+                    sequence_number: 5016,
+                    timestamp: 7000, 
+                    ..Default::default()
+                },
+                payload: bytes!(4u8),
+                ..Default::default()
+            },
+            rtp::packet::Packet { // Eigth packet
+                header: rtp::header::Header {
+                    sequence_number: 5017,
+                    timestamp: 7001, 
+                    ..Default::default()
+                },
+                payload: bytes!(5u8),
+                ..Default::default()
+            }]),
+            samples: Vec::from([Sample { // First sample
+                data: bytes!(4u8, 5u8),
+                duration: Duration::from_secs(2), 
+                packet_timestamp: 4000,
+                prev_dropped_packets: 13,
+                ..Default::default()
+            }]),
+            with_head_checker: true,
+            head_bytes: Vec::from([bytes!(4u8)]),
+            max_late: 50,
+            max_late_timestamp: Duration::from_secs(2000),
+            ..Default::default()
+        },
+        
+    ]);
+
+    for t in test_data {
+        let d = FakeDepacketizer {
+            head_checker: t.with_head_checker,
+            head_bytes: t.head_bytes,
+        };
+
+        let mut s = {
+            let sample_builder = SampleBuilder::new(t.max_late, d, 1);
+            if t.max_late_timestamp != Duration::from_secs(0) {
+                sample_builder.with_max_time_delay(t.max_late_timestamp)
+            } else {
+                sample_builder
+            }
+        };
+
+        let mut samples = Vec::<Sample>::new();
+        for p in t.packets {
+            s.push(p)
+        }
+
+        // Here we need some fancy loop that pops from s until empty. This propbably exists somewhere already.
+        // HAH, found it.
+        while let Some(sample) = s.pop() {
+            samples.push(sample)
+        }
+
+        // Current problem: Sample does not implement Eq. Either implement myself or find another way of comparison. (Derive does not work)
+        assert_eq!(t.samples, samples, "{}", t.message);
+    };
+}

--- a/src/io/sample_builder/sample_builder_test.rs
+++ b/src/io/sample_builder/sample_builder_test.rs
@@ -1,4 +1,3 @@
-
 use rtp::packetizer::Depacketizer;
 
 use super::*;
@@ -50,7 +49,7 @@ impl Depacketizer for FakeDepacketizer {
 
     /// Checks if the packet is at the end of a partition.  This should
     /// return false if the result could not be determined.
-    fn is_partition_tail(&self, marker: bool, payload: &Bytes) -> bool {
+    fn is_partition_tail(&self, marker: bool, _payload: &Bytes) -> bool {
         return marker;
     }
 }
@@ -112,7 +111,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Second packet
                 header: rtp::header::Header {
                     sequence_number: 5001,
-                    timestamp: 6, 
+                    timestamp: 6,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -121,7 +120,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5002,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -135,7 +134,7 @@ pub fn test_sample_builder() {
             },
             Sample { // Second sample
                 data: bytes!(2u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 6,
                 ..Default::default()
             }]),
@@ -150,7 +149,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 5, 
+                    timestamp: 5,
                     marker: true,
                     ..Default::default()
                 },
@@ -160,7 +159,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Second packet
                 header: rtp::header::Header {
                     sequence_number: 5002,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -169,7 +168,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5004,
-                    timestamp: 9, 
+                    timestamp: 9,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -178,7 +177,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fourth packet
                 header: rtp::header::Header {
                     sequence_number: 5006,
-                    timestamp: 11, 
+                    timestamp: 11,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -187,7 +186,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fifth packet
                 header: rtp::header::Header {
                     sequence_number: 5008,
-                    timestamp: 13, 
+                    timestamp: 13,
                     ..Default::default()
                 },
                 payload: bytes!(5u8),
@@ -196,7 +195,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Sixth packet
                 header: rtp::header::Header {
                     sequence_number: 5010,
-                    timestamp: 15, 
+                    timestamp: 15,
                     ..Default::default()
                 },
                 payload: bytes!(6u8),
@@ -205,7 +204,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Seventh packet
                 header: rtp::header::Header {
                     sequence_number: 5012,
-                    timestamp: 17, 
+                    timestamp: 17,
                     ..Default::default()
                 },
                 payload: bytes!(7u8),
@@ -213,7 +212,7 @@ pub fn test_sample_builder() {
             }]),
             samples: Vec::from([Sample { // First sample
                 data: bytes!(1u8),
-                duration: Duration::from_secs(2), 
+                duration: Duration::from_secs(2),
                 packet_timestamp: 5,
                 ..Default::default()
             }]),
@@ -237,7 +236,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Second packet
                 header: rtp::header::Header {
                     sequence_number: 5002,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -246,7 +245,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5004,
-                    timestamp: 9, 
+                    timestamp: 9,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -255,7 +254,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fourth packet
                 header: rtp::header::Header {
                     sequence_number: 5006,
-                    timestamp: 11, 
+                    timestamp: 11,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -264,7 +263,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fifth packet
                 header: rtp::header::Header {
                     sequence_number: 5008,
-                    timestamp: 13, 
+                    timestamp: 13,
                     ..Default::default()
                 },
                 payload: bytes!(5u8),
@@ -273,7 +272,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Sixth packet
                 header: rtp::header::Header {
                     sequence_number: 5010,
-                    timestamp: 15, 
+                    timestamp: 15,
                     ..Default::default()
                 },
                 payload: bytes!(6u8),
@@ -282,7 +281,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Seventh packet
                 header: rtp::header::Header {
                     sequence_number: 5012,
-                    timestamp: 17, 
+                    timestamp: 17,
                     ..Default::default()
                 },
                 payload: bytes!(7u8),
@@ -300,7 +299,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 5, 
+                    timestamp: 5,
                     marker: true,
                     ..Default::default()
                 },
@@ -311,7 +310,7 @@ pub fn test_sample_builder() {
                 header: rtp::header::Header {
                     sequence_number: 5002,
                     timestamp: 7,
-                    marker: true, 
+                    marker: true,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -320,7 +319,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5004,
-                    timestamp: 9, 
+                    timestamp: 9,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -329,7 +328,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fourth packet
                 header: rtp::header::Header {
                     sequence_number: 5006,
-                    timestamp: 11, 
+                    timestamp: 11,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -338,7 +337,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fifth packet
                 header: rtp::header::Header {
                     sequence_number: 5008,
-                    timestamp: 13, 
+                    timestamp: 13,
                     ..Default::default()
                 },
                 payload: bytes!(5u8),
@@ -347,7 +346,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Sixth packet
                 header: rtp::header::Header {
                     sequence_number: 5010,
-                    timestamp: 15, 
+                    timestamp: 15,
                     ..Default::default()
                 },
                 payload: bytes!(6u8),
@@ -356,7 +355,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Seventh packet
                 header: rtp::header::Header {
                     sequence_number: 5012,
-                    timestamp: 17, 
+                    timestamp: 17,
                     ..Default::default()
                 },
                 payload: bytes!(7u8),
@@ -364,13 +363,13 @@ pub fn test_sample_builder() {
             }]),
             samples: Vec::from([Sample { // First (dropped) sample
                 data: bytes!(1u8),
-                duration: Duration::from_secs(2), 
+                duration: Duration::from_secs(2),
                 packet_timestamp: 5,
                 ..Default::default()
             },
             Sample { // First correct sample
                 data: bytes!(2u8),
-                duration: Duration::from_secs(2), 
+                duration: Duration::from_secs(2),
                 packet_timestamp: 7,
                 prev_dropped_packets: 1,
                 ..Default::default()
@@ -386,7 +385,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 5, 
+                    timestamp: 5,
                     marker: true,
                     ..Default::default()
                 },
@@ -397,7 +396,7 @@ pub fn test_sample_builder() {
                 header: rtp::header::Header {
                     sequence_number: 5001,
                     timestamp: 6,
-                    marker: true, 
+                    marker: true,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -406,7 +405,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5002,
-                    timestamp: 6, 
+                    timestamp: 6,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -415,7 +414,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fourth packet
                 header: rtp::header::Header {
                     sequence_number: 5003,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -423,13 +422,13 @@ pub fn test_sample_builder() {
             }]),
             samples: Vec::from([Sample { // First sample
                 data: bytes!(1u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 5,
                 ..Default::default()
             },
             Sample { // Second (duplicate) correct sample
                 data: bytes!(2u8, 2u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 6,
                 ..Default::default()
             }]),
@@ -444,7 +443,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 5, 
+                    timestamp: 5,
                     marker: true,
                     ..Default::default()
                 },
@@ -455,7 +454,7 @@ pub fn test_sample_builder() {
                 header: rtp::header::Header {
                     sequence_number: 5007,
                     timestamp: 6,
-                    marker: true, 
+                    marker: true,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -464,7 +463,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5008,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -482,7 +481,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 5, 
+                    timestamp: 5,
                     marker: true,
                     ..Default::default()
                 },
@@ -493,7 +492,7 @@ pub fn test_sample_builder() {
                 header: rtp::header::Header {
                     sequence_number: 5007,
                     timestamp: 6,
-                    marker: true, 
+                    marker: true,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -502,7 +501,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5008,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -522,7 +521,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 5, 
+                    timestamp: 5,
                     marker: true,
                     ..Default::default()
                 },
@@ -533,7 +532,7 @@ pub fn test_sample_builder() {
                 header: rtp::header::Header {
                     sequence_number: 5007,
                     timestamp: 6,
-                    marker: true, 
+                    marker: true,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -542,7 +541,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5008,
-                    timestamp: 7, 
+                    timestamp: 7,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -562,7 +561,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 1, 
+                    timestamp: 1,
                     ..Default::default()
                 },
                 payload: bytes!(1u8),
@@ -571,7 +570,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Second packet
                 header: rtp::header::Header {
                     sequence_number: 5001,
-                    timestamp: 2, 
+                    timestamp: 2,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -580,7 +579,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5002,
-                    timestamp: 3, 
+                    timestamp: 3,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -589,7 +588,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fourth packet
                 header: rtp::header::Header {
                     sequence_number: 5003,
-                    timestamp: 4, 
+                    timestamp: 4,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -598,7 +597,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fifth packet
                 header: rtp::header::Header {
                     sequence_number: 5004,
-                    timestamp: 5, 
+                    timestamp: 5,
                     ..Default::default()
                 },
                 payload: bytes!(5u8),
@@ -607,7 +606,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Sixth packet
                 header: rtp::header::Header {
                     sequence_number: 5005,
-                    timestamp: 6, 
+                    timestamp: 6,
                     ..Default::default()
                 },
                 payload: bytes!(6u8),
@@ -615,31 +614,31 @@ pub fn test_sample_builder() {
             }]),
             samples: Vec::from([Sample { // First sample
                 data: bytes!(1u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 1,
                 ..Default::default()
             },
             Sample { // Second sample
                 data: bytes!(2u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 2,
                 ..Default::default()
             },
             Sample { // Third sample
                 data: bytes!(3u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 3,
                 ..Default::default()
             },
             Sample { // Fourth sample
                 data: bytes!(4u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 4,
                 ..Default::default()
             },
             Sample { // Fifth sample
                 data: bytes!(5u8),
-                duration: Duration::from_secs(1), 
+                duration: Duration::from_secs(1),
                 packet_timestamp: 5,
                 ..Default::default()
             },]),
@@ -654,7 +653,7 @@ pub fn test_sample_builder() {
             packets: Vec::<rtp::packet::Packet>::from([rtp::packet::Packet { // First packet
                 header: rtp::header::Header {
                     sequence_number: 5000,
-                    timestamp: 1, 
+                    timestamp: 1,
                     ..Default::default()
                 },
                 payload: bytes!(1u8),
@@ -663,7 +662,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Second packet
                 header: rtp::header::Header {
                     sequence_number: 5001,
-                    timestamp: 2, 
+                    timestamp: 2,
                     ..Default::default()
                 },
                 payload: bytes!(2u8),
@@ -672,7 +671,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Third packet
                 header: rtp::header::Header {
                     sequence_number: 5002,
-                    timestamp: 3, 
+                    timestamp: 3,
                     ..Default::default()
                 },
                 payload: bytes!(3u8),
@@ -681,7 +680,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fourth packet
                 header: rtp::header::Header {
                     sequence_number: 5013,
-                    timestamp: 4000, 
+                    timestamp: 4000,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -690,7 +689,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Fifth packet
                 header: rtp::header::Header {
                     sequence_number: 5014,
-                    timestamp: 4000, 
+                    timestamp: 4000,
                     ..Default::default()
                 },
                 payload: bytes!(5u8),
@@ -699,7 +698,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Sixth packet
                 header: rtp::header::Header {
                     sequence_number: 5015,
-                    timestamp: 4002, 
+                    timestamp: 4002,
                     ..Default::default()
                 },
                 payload: bytes!(6u8),
@@ -708,7 +707,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Seventh packet
                 header: rtp::header::Header {
                     sequence_number: 5016,
-                    timestamp: 7000, 
+                    timestamp: 7000,
                     ..Default::default()
                 },
                 payload: bytes!(4u8),
@@ -717,7 +716,7 @@ pub fn test_sample_builder() {
             rtp::packet::Packet { // Eigth packet
                 header: rtp::header::Header {
                     sequence_number: 5017,
-                    timestamp: 7001, 
+                    timestamp: 7001,
                     ..Default::default()
                 },
                 payload: bytes!(5u8),
@@ -725,7 +724,7 @@ pub fn test_sample_builder() {
             }]),
             samples: Vec::from([Sample { // First sample
                 data: bytes!(4u8, 5u8),
-                duration: Duration::from_secs(2), 
+                duration: Duration::from_secs(2),
                 packet_timestamp: 4000,
                 prev_dropped_packets: 13,
                 ..Default::default()
@@ -736,7 +735,7 @@ pub fn test_sample_builder() {
             max_late_timestamp: Duration::from_secs(2000),
             ..Default::default()
         },
-        
+
     ]);
 
     for t in test_data {
@@ -767,5 +766,5 @@ pub fn test_sample_builder() {
 
         // Current problem: Sample does not implement Eq. Either implement myself or find another way of comparison. (Derive does not work)
         assert_eq!(t.samples, samples, "{}", t.message);
-    };
+    }
 }

--- a/src/io/sample_builder/sample_sequence_location.rs
+++ b/src/io/sample_builder/sample_sequence_location.rs
@@ -1,0 +1,55 @@
+use super::seqnum_distance;
+
+#[derive(PartialEq)]
+pub(crate) enum Comparison {
+    Void,
+    Before,
+    Inside,
+    After,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct SampleSequenceLocation {
+    /// head is the first packet in a sequence
+    pub(crate) head: u16,
+    /// tail is always set to one after the final sequence number,
+    /// so if head == tail then the sequence is empty
+    pub(crate) tail: u16,
+}
+
+impl SampleSequenceLocation {
+    pub(crate) fn new() -> Self {
+        Self { head: 0, tail: 0 }
+    }
+
+    pub(crate) fn empty(&self) -> bool {
+        self.head == self.tail
+    }
+
+    pub(crate) fn has_data(&self) -> bool {
+        self.head != self.tail
+    }
+
+    pub(crate) fn count(&self) -> u16 {
+        seqnum_distance(self.head, self.tail)
+    }
+
+    pub(crate) fn compare(&self, pos: u16) -> Comparison {
+        if self.head == self.tail {
+            return Comparison::Void;
+        }
+        if self.head < self.tail {
+            if self.head <= pos && pos < self.tail {
+                return Comparison::Inside;
+            }
+        } else {
+            if self.head <= pos || pos < self.tail {
+                return Comparison::Inside;
+            }
+        }
+        if self.head.wrapping_sub(pos) <= pos.wrapping_sub(self.tail) {
+            return Comparison::Before;
+        }
+        Comparison::After
+    }
+}

--- a/src/io/sample_builder/sample_sequence_location.rs
+++ b/src/io/sample_builder/sample_sequence_location.rs
@@ -13,7 +13,7 @@ pub(crate) struct SampleSequenceLocation {
     /// head is the first packet in a sequence
     pub(crate) head: u16,
     /// tail is always set to one after the final sequence number,
-    /// so if head == tail then the sequence is empty
+    /// so if `head == tail` then the sequence is empty
     pub(crate) tail: u16,
 }
 

--- a/src/io/sample_builder/sample_sequence_location.rs
+++ b/src/io/sample_builder/sample_sequence_location.rs
@@ -1,6 +1,6 @@
 use super::seqnum_distance;
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum Comparison {
     Void,
     Before,

--- a/src/io/sample_builder/sample_sequence_location_test.rs
+++ b/src/io/sample_builder/sample_sequence_location_test.rs
@@ -1,0 +1,24 @@
+use super::sample_sequence_location::*;
+
+#[test]
+fn test_sample_sequence_location_compare() {
+    let s1 = SampleSequenceLocation { head: 32, tail: 42 };
+    assert_eq!(Comparison::Before, s1.compare(16));
+    assert_eq!(Comparison::Inside, s1.compare(32));
+    assert_eq!(Comparison::Inside, s1.compare(38));
+    assert_eq!(Comparison::Inside, s1.compare(41));
+    assert_eq!(Comparison::After, s1.compare(42));
+    assert_eq!(Comparison::After, s1.compare(0x57));
+
+    let s2 = SampleSequenceLocation {
+        head: 0xffa0,
+        tail: 32,
+    };
+    assert_eq!(Comparison::Before, s2.compare(0xff00));
+    assert_eq!(Comparison::Inside, s2.compare(0xffa0));
+    assert_eq!(Comparison::Inside, s2.compare(0xffff));
+    assert_eq!(Comparison::Inside, s2.compare(0));
+    assert_eq!(Comparison::Inside, s2.compare(31));
+    assert_eq!(Comparison::After, s2.compare(32));
+    assert_eq!(Comparison::After, s2.compare(128));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use std::time::{Duration, SystemTime};
 
 /// A Sample contains encoded media and timing information
+#[derive(Debug)]
 pub struct Sample {
     pub data: Bytes,
     pub timestamp: SystemTime,
@@ -30,5 +31,29 @@ impl Default for Sample {
             packet_timestamp: 0,
             prev_dropped_packets: 0,
         }
+    }
+}
+
+impl PartialEq for Sample {
+    fn eq(&self, other: &Self) -> bool {
+        let mut equal: bool = true;
+        if self.data != other.data {
+            equal = false;
+        }
+        if self.timestamp.elapsed().unwrap().as_secs()
+            != other.timestamp.elapsed().unwrap().as_secs()
+        {
+            equal = false;
+        }
+        if self.duration != other.duration {
+            equal = false;
+        }
+        if self.packet_timestamp != other.packet_timestamp {
+            equal = false;
+        }
+        if self.prev_dropped_packets != other.prev_dropped_packets {
+            equal = false;
+        }
+        equal
     }
 }


### PR DESCRIPTION
Ported from https://github.com/pion/webrtc/tree/master/pkg/media/samplebuilder.
The sample builder is needed for gathering all RTP packets that form a single frame, which can then be used to decode the data.
Once this is merged, we can contribute an according example for decoding VPx/H264/Opus tracks received from WebRTC through ffmpeg or libvpx.

TODO:

- [x] Port unit tests
- [ ] Reduce memory usage of ring buffers (`buffer` and `prepared_samples`)
- [ ] Make the implementation more 'idiomatic' (currently it's a mostly 1:1 port from Go)