### PR TITLE
update deps + loosen some requirements 

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -69,7 +69,11 @@ jobs:
     name: Compile and test with minimal versions
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        # TODO: add 'windows-latest' once criterion#atty version is upgraded
+        # "0.2" min version (0.2.0) depends on winapi-0.2.4 which does not
+        # compile on nightly.
+        # https://github.com/bheisler/criterion.rs/pull/587
+        os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ repository = "https://github.com/webrtc-rs/media"
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["marshal"] }
 rtp = "0.6.5"
-byteorder = "1.4.3"
-bytes = "1.1.0"
+byteorder = "1"
+bytes = "1"
 displaydoc = "0.2.3"
-thiserror = "1.0.30"
-rand = "0.8.4"
-derive_builder = "0.10.2"
+thiserror = "1.0"
+rand = "0.8.5"
+derive_builder = "0.11.2"
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/webrtc-rs/media"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["marshal"] }
+util = { package = "webrtc-util", version = "0.5.4", default-features = false, features = ["marshal"] }
 rtp = "0.6.5"
 byteorder = "1"
 bytes = "1"

--- a/src/audio/buffer.rs
+++ b/src/audio/buffer.rs
@@ -31,7 +31,7 @@ pub trait ToByteBufferRef<L>: Sized {
     ) -> Result<usize, Self::Error>;
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error {
     #[error("Unexpected end of buffer: (expected: {expected}, actual: {actual})")]
     UnexpectedEndOfBuffer { expected: usize, actual: usize },

--- a/src/io/h264_reader/mod.rs
+++ b/src/io/h264_reader/mod.rs
@@ -9,7 +9,7 @@ use std::io::Read;
 
 /// NalUnitType is the type of a NAL
 /// Enums for NalUnitTypes
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NalUnitType {
     /// Unspecified
     Unspecified = 0,

--- a/src/io/ivf_reader/mod.rs
+++ b/src/io/ivf_reader/mod.rs
@@ -14,7 +14,7 @@ pub const IVF_FRAME_HEADER_SIZE: usize = 12;
 
 /// IVFFileHeader 32-byte header for IVF files
 /// https://wiki.multimedia.cx/index.php/IVF
-#[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct IVFFileHeader {
     pub signature: [u8; 4],        // 0-3
     pub version: u16,              // 4-5
@@ -30,7 +30,7 @@ pub struct IVFFileHeader {
 
 /// IVFFrameHeader 12-byte header for IVF frames
 /// https://wiki.multimedia.cx/index.php/IVF
-#[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct IVFFrameHeader {
     pub frame_size: u32, // 0-3
     pub timestamp: u64,  // 4-11

--- a/src/track/constraint/numeric.rs
+++ b/src/track/constraint/numeric.rs
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn fitness_distance_exists() {
         fn fitness(is_expected: bool, is_required: bool, setting: Option<u32>) -> f64 {
-            let actual = setting.map(|t| t);
+            let actual = setting;
             Numeric::<u32>::exists(is_expected)
                 .is_required(is_required)
                 .fitness_distance(actual.as_ref())
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn fitness_distance_exactly() {
         fn fitness(value: u32, is_required: bool, setting: Option<u32>) -> f64 {
-            let actual = setting.map(|t| t);
+            let actual = setting;
             Numeric::<u32>::exactly(value)
                 .is_required(is_required)
                 .fitness_distance(actual.as_ref())
@@ -270,8 +270,8 @@ mod tests {
     #[test]
     fn fitness_distance_at_least() {
         fn fitness(min: u32, ideal: Option<u32>, is_required: bool, setting: Option<u32>) -> f64 {
-            let ideal = ideal.map(|t| t);
-            let actual = setting.map(|t| t);
+            let ideal = ideal;
+            let actual = setting;
             Numeric::<u32>::at_least(min, ideal)
                 .is_required(is_required)
                 .fitness_distance(actual.as_ref())
@@ -298,8 +298,8 @@ mod tests {
     #[test]
     fn fitness_distance_at_most() {
         fn fitness(max: u32, ideal: Option<u32>, is_required: bool, setting: Option<u32>) -> f64 {
-            let ideal = ideal.map(|t| t);
-            let actual = setting.map(|t| t);
+            let ideal = ideal;
+            let actual = setting;
             Numeric::<u32>::at_most(max, ideal)
                 .is_required(is_required)
                 .fitness_distance(actual.as_ref())
@@ -332,8 +332,8 @@ mod tests {
             is_required: bool,
             setting: Option<u32>,
         ) -> f64 {
-            let ideal = ideal.map(|t| t);
-            let actual = setting.map(|t| t);
+            let ideal = ideal;
+            let actual = setting;
             Numeric::<u32>::within(min, max, ideal)
                 .is_required(is_required)
                 .fitness_distance(actual.as_ref())

--- a/src/track/setting/video/facing_mode.rs
+++ b/src/track/setting/video/facing_mode.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Debug, str::FromStr};
 
 use thiserror::Error;
 
-#[derive(Error, PartialEq, Debug)]
+#[derive(Error, PartialEq, Eq, Debug)]
 pub enum FacingModeParsingError {
     #[error("Unknown facing mode: {value}")]
     UnknownValue { value: String },

--- a/src/track/setting/video/resize_mode.rs
+++ b/src/track/setting/video/resize_mode.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Debug, str::FromStr};
 
 use thiserror::Error;
 
-#[derive(Error, PartialEq, Debug)]
+#[derive(Error, PartialEq, Eq, Debug)]
 pub enum ResizeModeParsingError {
     #[error("Unknown facing mode: {value}")]
     UnknownValue { value: String },


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions